### PR TITLE
hide case status filter from AdditionalFilters

### DIFF
--- a/components/search/AdditionalFilters.tsx
+++ b/components/search/AdditionalFilters.tsx
@@ -29,7 +29,7 @@ const AdditionalFilters: React.FC<AdditionalFiltersProps> = ({
   courtOptions,
   caseStageOptions,
   caseTypeOptions,
-  caseStatusOptions,
+  // caseStatusOptions,
 }) => {
   const { t } = useSafeTranslation();
   // Local state to track filter changes before applying them
@@ -217,7 +217,7 @@ const AdditionalFilters: React.FC<AdditionalFiltersProps> = ({
               className="bg-[#F8FAFC] border-[#94A3B8]"
             />
 
-            <CustomDropdown
+            {/* <CustomDropdown
               label="CASE_STATUS"
               placeHolder="SELECT_CASE_STATUS"
               value={localFilters.caseStatus}
@@ -229,7 +229,7 @@ const AdditionalFilters: React.FC<AdditionalFiltersProps> = ({
                 })) || []
               }
               className="bg-[#F8FAFC] border-[#94A3B8]"
-            />
+            /> */}
 
             <CustomDropdown
               label="YEAR_OF_FILING"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Simplified the search filters by removing the Case Status option from Additional Filters. All other filters (Court, Case Type, Case Stage, Year of Filing, Date Range) remain available.
- Refactor
  - Streamlined the filter UI to reduce clutter and focus on commonly used options. Apply and Reset actions continue to work as before, with no changes to existing filter behavior aside from the removal of Case Status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->